### PR TITLE
rename coreboot.rom to tianocore.rom

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,9 +19,9 @@ variables:
   COMMON_GITHUB_RELEASE: "false"
   COMMON_UPLOAD_FILES: "true"
   DEVICE_FOLDER: "nitropc"
-  UPLOAD_FOLDER: "coreboot"
+  UPLOAD_FOLDER: "tianocore"
 
-build-coreboot:
+build-tianocore:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "push"'
   tags:
@@ -30,7 +30,7 @@ build-coreboot:
   script:
     - make
     - mkdir -p artifacts
-    - cp coreboot*.rom artifacts/
+    - cp tianocore*.rom artifacts/
   after_script:
     - wget $icon_server/checkmark/$CI_COMMIT_REF_NAME/$CI_COMMIT_SHA/$CI_JOB_NAME/$CI_JOB_STATUS/${CI_JOB_URL#*/*/*/}
   artifacts:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BASEDIR=$(shell pwd)
 CONTNAME=coreboot-builder
 SRCDIR=$(BASEDIR)
 COREBOOT_VERSION = 4.13
-OUTPUT_NAME = coreboot-$(COREBOOT_VERSION).rom
+OUTPUT_NAME = tianocore-$(COREBOOT_VERSION).rom
 
 DOCKERDIR=$(BASEDIR)
 #DOCKERUIDGID=--user $(shell id -u):$(shell id -g)
@@ -17,7 +17,7 @@ firmware.rom: raw_firmware.rom
 	# -> BUILD DONE
 	# 
 	# you can now flash the firmware: 
-	# $ ./flash.sh coreboot-[version].rom
+	# $ ./flash.sh tianocore-[version].rom
 	# 
 	#
 


### PR DESCRIPTION
Renaming CI output file -> coreboot-[ver].rom to tianocore-[ver].rom
Files: https://www.nitrokey.com/files/ci/nitropc/tianocore/
Build: https://git.dotplex.com/nitrokey/coreboot-builder/-/pipelines/15422